### PR TITLE
Fix/putbytes

### DIFF
--- a/point.go
+++ b/point.go
@@ -39,10 +39,10 @@ package secp256k1
 // generator as a non static variable. The use of the macro is copied from
 // group_impl.h.
 const secp256k1_ge secp256k1_generator = SECP256K1_GE_CONST(
-    0x79BE667EUL, 0xF9DCBBACUL, 0x55A06295UL, 0xCE870B07UL,
-    0x029BFCDBUL, 0x2DCE28D9UL, 0x59F2815BUL, 0x16F81798UL,
-    0x483ADA77UL, 0x26A3C465UL, 0x5DA4FBFCUL, 0x0E1108A8UL,
-    0xFD17B448UL, 0xA6855419UL, 0x9C47D08FUL, 0xFB10D4B8UL
+	0x79BE667EUL, 0xF9DCBBACUL, 0x55A06295UL, 0xCE870B07UL,
+	0x029BFCDBUL, 0x2DCE28D9UL, 0x59F2815BUL, 0x16F81798UL,
+	0x483ADA77UL, 0x26A3C465UL, 0x5DA4FBFCUL, 0x0E1108A8UL,
+	0xFD17B448UL, 0xA6855419UL, 0x9C47D08FUL, 0xFB10D4B8UL
 );
 
 // The c null pointer, which we define as it may be different from the go nil
@@ -251,9 +251,6 @@ func (p *Point) IsOnCurve() bool {
 }
 
 // Eq returns true if the two curve points are equal, and false otherwise.
-//
-// NOTE: This modifies the representation of p, but it will still represent the
-// same point on the elliptic curve.
 func (p *Point) Eq(other *Point) bool {
 	if p.IsInfinity() != other.IsInfinity() {
 		return false
@@ -263,15 +260,20 @@ func (p *Point) Eq(other *Point) bool {
 		return true
 	}
 
+	pCopy := *p
+	otherCopy := *other
+
 	// Scale p so that the z fields are equal. Once the z fields are equal, the
 	// points will be equal if and only if the x and y fields are equal.
 	var s C.secp256k1_fe
-	C.secp256k1_fe_inv(&s, &p.inner.z)
-	C.secp256k1_fe_mul(&s, &s, &other.inner.z)
-	C.secp256k1_gej_rescale(&p.inner, &s) // Modifies representation of p.
-	normalizeXYZ(&p.inner)
+	C.secp256k1_fe_inv(&s, &pCopy.inner.z)
+	C.secp256k1_fe_mul(&s, &s, &otherCopy.inner.z)
+	C.secp256k1_gej_rescale(&pCopy.inner, &s)
 
-	return fpEq(&p.inner.x, &other.inner.x) && fpEq(&p.inner.y, &other.inner.y)
+	normalizeXYZ(&pCopy.inner)
+	normalizeXYZ(&otherCopy.inner)
+
+	return fpEq(&pCopy.inner.x, &otherCopy.inner.x) && fpEq(&pCopy.inner.y, &otherCopy.inner.y)
 }
 
 // BaseExp computes the scalar multiplication of the canonical generator of the

--- a/point.go
+++ b/point.go
@@ -165,9 +165,11 @@ func (p *Point) PutBytes(dst []byte) {
 	}
 
 	var tmp C.secp256k1_ge
-	C.secp256k1_ge_set_gej(&tmp, &p.inner)
+	pCopy := *p
+	C.secp256k1_ge_set_gej(&tmp, &pCopy.inner)
+	C.secp256k1_fe_normalize_var(&tmp.x)
 
-	if p.IsInfinity() {
+	if pCopy.IsInfinity() {
 		dst[0] = 0xFF
 	} else {
 		dst[0] = byte(tmp.y.n[0] & 1)

--- a/point.go
+++ b/point.go
@@ -168,6 +168,7 @@ func (p *Point) PutBytes(dst []byte) {
 	pCopy := *p
 	C.secp256k1_ge_set_gej(&tmp, &pCopy.inner)
 	C.secp256k1_fe_normalize_var(&tmp.x)
+	C.secp256k1_fe_normalize_var(&tmp.y)
 
 	if pCopy.IsInfinity() {
 		dst[0] = 0xFF

--- a/point_test.go
+++ b/point_test.go
@@ -531,7 +531,7 @@ var _ = Describe("Point", func() {
 		})
 	})
 
-	FContext("regression tests", func() {
+	Context("regression tests", func() {
 		unnormalisedPoint := func() Point {
 			// Previously determined value that leads to the bad curve point.
 			scalarInt, _ := big.NewInt(0).SetString("104594261325654521456437189213270314662855164308234370710339505268369968110053", 10)

--- a/point_test.go
+++ b/point_test.go
@@ -532,9 +532,11 @@ var _ = Describe("Point", func() {
 	})
 
 	Context("regression tests", func() {
-		unnormalisedPoint := func() Point {
+		bad := "104594261325654521456437189213270314662855164308234370710339505268369968110053"
+		bady := "63841638568451640125764236139710619670518082485545205673739600116664829291880"
+		unnormalisedPoint := func(str string) (Point, Point) {
 			// Previously determined value that leads to the bad curve point.
-			scalarInt, _ := big.NewInt(0).SetString("104594261325654521456437189213270314662855164308234370710339505268369968110053", 10)
+			scalarInt, _ := big.NewInt(0).SetString(str, 10)
 			buf := [32]byte{}
 			scalarInt.FillBytes(buf[:])
 			scalar := Fn{}
@@ -542,28 +544,16 @@ var _ = Describe("Point", func() {
 
 			// Base exponentiation causes the `z` value in the gej representation to
 			// not be 1.
-			unnormalised := Point{}
-			unnormalised.BaseExp(&scalar)
+			normalised := Point{}
+			normalised.BaseExp(&scalar)
+			unnormalised := normalised
 			tmp := Point{}
 
 			// Scaling causes the base to be rescaled, which for our specifically
 			// chosen base will cause the `x` and/or `y` values in the gej
 			// representation to be not normalised.
 			tmp.Scale(&unnormalised, &scalar)
-			return unnormalised
-		}
-
-		willBecomeUnnormalisedPoint := func() Point {
-			scalarInt, _ := big.NewInt(0).SetString("104594261325654521456437189213270314662855164308234370710339505268369968110053", 10)
-			buf := [32]byte{}
-			scalarInt.FillBytes(buf[:])
-			scalar := Fn{}
-			scalar.SetB32(buf[:])
-
-			primed := Point{}
-			primed.BaseExp(&scalar)
-
-			return primed
+			return normalised, unnormalised
 		}
 
 		It("should handle point equality correctly", func() {
@@ -571,21 +561,30 @@ var _ = Describe("Point", func() {
 			// At this stage we have a bad point that is in a non-normalised
 			// representation. We can get a normalised representation by
 			// calling a method that normalises the caller, for example `Eq`.
-			unnormalised := unnormalisedPoint()
-			normalised := unnormalised
-			normalised.Eq(&normalised)
+			normalised, unnormalised := unnormalisedPoint(bad)
 			Expect(normalised.Eq(&unnormalised)).To(BeTrue())
 		})
 
 		It("should marshal correctly", func() {
-			unnormalised := willBecomeUnnormalisedPoint()
+			point, _ := unnormalisedPoint(bad)
 			buf := [33]byte{}
-			unnormalised.PutBytes(buf[:])
+			point.PutBytes(buf[:])
 
 			after := Point{}
 			after.SetBytes(buf[:])
 
-			Expect(after.Eq(&unnormalised)).To(BeTrue())
+			Expect(after.Eq(&point)).To(BeTrue())
+		})
+
+		It("should marshal correctly with unnormalised y", func() {
+			point, _ := unnormalisedPoint(bady)
+			buf := [33]byte{}
+			point.PutBytes(buf[:])
+
+			after := Point{}
+			after.SetBytes(buf[:])
+
+			Expect(after.Eq(&point)).To(BeTrue())
 		})
 	})
 })


### PR DESCRIPTION
This PR resolves #23.

The fix is to normalise the `x` coordinate of the point, which gets passed to a function that assumes a normalised input. Additionally, a copy of the receiver is made so that this normalisation doesn't affect the receiver.

EDIT: The `y` coordinate is now also normalised, because it is used to calculate the recovery id.