### PR TITLE
Return normalised point coordinates

### DIFF
--- a/point.go
+++ b/point.go
@@ -156,6 +156,7 @@ func (p *Point) XY() (Fp, Fp, error) {
 	// to be unnormalised. We therefore normalise the point which will also
 	// ensure that the returned xy coordinates are also normalised.
 	normalizeXYZ(&p.inner)
+	normalizeXYZ(&tmp.inner)
 	x.inner = tmp.x
 	y.inner = tmp.y
 	return x, y, nil

--- a/point.go
+++ b/point.go
@@ -151,6 +151,11 @@ func (p *Point) XY() (Fp, Fp, error) {
 	var tmp C.secp256k1_ge
 
 	C.secp256k1_ge_set_gej(&tmp, &p.inner)
+	// Even though after the previous call `p` will represent the same curve
+	// point, the representation changes and can cause the x or y coordinates
+	// to be unnormalised. We therefore normalise the point which will also
+	// ensure that the returned xy coordinates are also normalised.
+	normalizeXYZ(&p.inner)
 	x.inner = tmp.x
 	y.inner = tmp.y
 	return x, y, nil

--- a/point.go
+++ b/point.go
@@ -156,9 +156,10 @@ func (p *Point) XY() (Fp, Fp, error) {
 	// to be unnormalised. We therefore normalise the point which will also
 	// ensure that the returned xy coordinates are also normalised.
 	normalizeXYZ(&p.inner)
-	normalizeXYZ(&tmp.inner)
 	x.inner = tmp.x
 	y.inner = tmp.y
+	x.normalize()
+	y.normalize()
 	return x, y, nil
 }
 


### PR DESCRIPTION
Many functions on the `Fp` type assume that the representation is normalised. This assumption is mostly upheld, but can be violated by the `Point.XY` function, that returns the xy coordinates of a point as two `Fp`s. This PR implements a fix so that the returned coordinates are normalised.